### PR TITLE
イベント作成のフロントエンド、バリデーションメッセージ一部変更

### DIFF
--- a/yeahcheese/app/Http/Requests/StoreEventRequest.php
+++ b/yeahcheese/app/Http/Requests/StoreEventRequest.php
@@ -38,11 +38,11 @@ class StoreEventRequest extends FormRequest
         'name.max' => '名前は255文字以内で入力してください',
         'start_date.required' => '公開開始日を入力してください',
         'start_date.date' => '日付の入力が不適切です',
-        'start_date.before_or_equal:end_date' => '公開終了日以前に設定してください',
-        'start_date.after:yesterday' => '当日以降に設定してください',
+        'start_date.before_or_equal' => '公開終了日以前に設定してください',
+        'start_date.after' => '本日以降に設定してください',
         'end_date.required' => '公開終了日を入力してください',
         'end_date.date' => '日付の入力が不適切です',
-        'end_date.after_or_equal:start_date' => '公開開始日以後に設定してください'
+        'end_date.after_or_equal' => '公開開始日以後に設定してください'
       ];
     }
 }

--- a/yeahcheese/resources/js/pages/eventStore.vue
+++ b/yeahcheese/resources/js/pages/eventStore.vue
@@ -1,0 +1,108 @@
+<template>
+  <form @submit.prevent="eventStore">
+    <validationMessages :errors="valiMessages" />
+    <div class="form-group">
+      <label for="name">名前</label>
+      <input
+        type="text"
+        class="form-control"
+        :class="isValid('name')"
+        id="name"
+        placeholder="名前"
+        v-model="eventStoreForm.name"
+      />
+    </div>
+    <div class="form-group">
+      <label for="exampleInputStartDate">公開開始日</label>
+      <input
+        type="date"
+        class="form-control"
+        :class="isValid('start_date')"
+        id="exampleInputStartDate"
+        placeholder="公開開始日"
+        v-model="eventStoreForm.start_date"
+      />
+    </div>
+    <div class="form-group">
+      <label for="exampleInputEndDate">公開終了日</label>
+      <input
+        type="date"
+        class="form-control"
+        :class="isValid('end_date')"
+        id="exampleInputEndDate"
+        placeholder="公開終了日"
+        v-model="eventStoreForm.end_date"
+      />
+    </div>
+    <button type="submit" class="btn btn-primary">登録</button>
+  </form>
+</template>
+
+<script>
+import api from "../api";
+import { mapGetters } from "vuex";
+import validationMessages from "../components/validationMessages";
+export default {
+  name: "EventStore",
+  components: {
+    validationMessages
+  },
+  data() {
+    return {
+      eventStoreForm: {
+        name: "",
+        start_date: "",
+        end_date: "",
+      },
+      validationMessages: []
+    };
+  },
+  computed: {
+    ...mapGetters({
+      isApiSuccess: "status/isApiSuccess"
+    }),
+    isValid() {
+      return function(form_name) {
+        return Object.keys(this.validationMessages).includes(form_name)
+          ? "is-invalid"
+          : "";
+      };
+    },
+    valiMessages() {
+      var response = [];
+      Object.values(this.validationMessages).forEach(val => {
+        if (Array.isArray(val)) {
+          val.forEach(val2 => {
+            response.push(val2);
+          });
+        } else {
+          response.push(val);
+        }
+      });
+      return response;
+    }
+  },
+  methods: {
+    async eventStore() {
+      this.delValidation();
+      const response = await this.$store.dispatch(
+        "events/eventStore",
+        this.eventStoreForm
+      );
+
+      if (this.isApiSuccess) {
+        this.$router.push({ path: "/events" });
+      } else {
+        this.validationMessages = response;
+      }
+    },
+    delValidation() {
+      this.validationMessages = [];
+    }
+  }
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/yeahcheese/resources/js/pages/eventStore.vue
+++ b/yeahcheese/resources/js/pages/eventStore.vue
@@ -72,8 +72,8 @@ export default {
       var response = [];
       Object.values(this.validationMessages).forEach(val => {
         if (Array.isArray(val)) {
-          val.forEach(val2 => {
-            response.push(val2);
+          val.forEach(innerText => {
+            response.push(innerText);
           });
         } else {
           response.push(val);

--- a/yeahcheese/resources/js/pages/register.vue
+++ b/yeahcheese/resources/js/pages/register.vue
@@ -84,8 +84,8 @@ export default {
       var response = [];
       Object.values(this.validationMessages).forEach(val => {
         if (Array.isArray(val)) {
-          val.forEach(val2 => {
-            response.push(val2);
+          val.forEach(innerText => {
+            response.push(innerText);
           });
         } else {
           response.push(val);

--- a/yeahcheese/resources/js/router/index.js
+++ b/yeahcheese/resources/js/router/index.js
@@ -9,6 +9,7 @@ import E401 from '../pages/401.vue';
 import E403 from '../pages/403.vue';
 import E404 from '../pages/404.vue';
 import E500 from '../pages/500.vue';
+import EventStore from '../pages/eventStore.vue'
 
 Vue.use(Router);
 
@@ -41,6 +42,10 @@ const routes = [
     path: '/register',
     component: Register,
     meta: { requiresNotAuth: true }
+  },
+  {
+    path: '/events/new',
+    component: EventStore
   }
 ];
 

--- a/yeahcheese/resources/js/store/events/actions.js
+++ b/yeahcheese/resources/js/store/events/actions.js
@@ -1,11 +1,16 @@
 import * as types from '../mutation-types';
+import api from "../../api";
+import store from "../../store";
 
 export default {
-  // ? 以下のように使える、と思う
-  // getEvent({ commit }) {
-  //   ...apiを叩いて、イベント情報を取得する処理
-  //   ...
-  //   payload = { id: ..., name: ..., photos: ... };
-  //   commit(types.SET_EVENT, payload);
-  // }
+  async eventStore(context, data) {
+    let response = await api.eventPost(data);
+    const isSuccess = store.getters["status/isApiSuccess"];
+    if (isSuccess) {
+      context.commit("setEvent", response);
+      return response
+    } else {
+      return response.errors;
+    }
+  }
 }

--- a/yeahcheese/resources/js/store/events/index.js
+++ b/yeahcheese/resources/js/store/events/index.js
@@ -2,8 +2,9 @@ import mutations from './mutations';
 import getters from './getters';
 import actions from './actions';
 
-const state = () => {
-  // test: 'テストの値'
+const state = {
+  events: [],
+  validationMessage: []
 }
 
 export default {

--- a/yeahcheese/resources/js/store/events/mutations.js
+++ b/yeahcheese/resources/js/store/events/mutations.js
@@ -1,9 +1,11 @@
 import * as types from '../mutation-types';
 
 export default {
-  // TODO: ステート内のイベントを更新する処理
-  // TODO: dispatch(types.SET_EVENT, payload) で、このミューテーションが呼び出される
-  // [types.SET_EVENT](state, payload) {
-  // },
-  // ... ステートが更新される
+  setEventValidationMessage(state, mes) {
+    state.validationMessage = mes
+  },
+
+  setEvent(state, event) {
+    state.events.push(event)
+  }
 }


### PR DESCRIPTION
イベント作成
バリデーションエラー表示欄確保
作成後 詳細へ遷移
resolve:#8
- - -
イベント作成フォーム
<img width="545" alt="スクリーンショット 2020-05-18 12 52 48" src="https://user-images.githubusercontent.com/48024154/82173132-33236580-9907-11ea-9e27-8d184c6d9bb8.png">
- - -
バリデーションエラーメッセージ
<img width="547" alt="スクリーンショット 2020-05-18 12 56 24" src="https://user-images.githubusercontent.com/48024154/82173147-3ae30a00-9907-11ea-8892-25518fdcdad5.png">

