### PR TITLE
Feature/create middleware for authenticate event（ゲストユーザーが公開期限外のイベントにアクセスした際に弾く）

### DIFF
--- a/yeahcheese/app/Http/Controllers/Api/EventsController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventsController.php
@@ -33,11 +33,9 @@ class EventsController extends Controller
             $opt = $request->only('status', 'path');
             $resource = new EventResource($event);
             $resource->additional($opt);
-            dd($resource);
             return $resource;
         }
         $response = $request->only('errors', 'status', 'key');
-        dd($response);
         return response($response);
     }
 

--- a/yeahcheese/app/Http/Controllers/Api/EventsController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventsController.php
@@ -28,15 +28,16 @@ class EventsController extends Controller
 
     public function auth(Request $request)
     {
-        $event = Event::all()->where("key", $request->key)->first();
         if (is_null($request->errors)) {
             $event = $request->event;
             $opt = $request->only('status', 'path');
             $resource = new EventResource($event);
             $resource->additional($opt);
+            dd($resource);
             return $resource;
         }
         $response = $request->only('errors', 'status', 'key');
+        dd($response);
         return response($response);
     }
 

--- a/yeahcheese/app/Http/Controllers/Api/EventsController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventsController.php
@@ -15,6 +15,8 @@ class EventsController extends Controller
     {
         $this->middleware('auth:sanctum')
             ->except(['auth', 'show']);
+        $this->middleware('auth-event')
+            ->only(['auth']);
     }
     /**
      * イベント一覧取得

--- a/yeahcheese/app/Http/Controllers/Api/EventsController.php
+++ b/yeahcheese/app/Http/Controllers/Api/EventsController.php
@@ -29,10 +29,15 @@ class EventsController extends Controller
     public function auth(Request $request)
     {
         $event = Event::all()->where("key", $request->key)->first();
-        if (!$event) {
-            return response("認証キーが間違っています", 406);
+        if (is_null($request->errors)) {
+            $event = $request->event;
+            $opt = $request->only('status', 'path');
+            $resource = new EventResource($event);
+            $resource->additional($opt);
+            return $resource;
         }
-        return response($event, 200);
+        $response = $request->only('errors', 'status', 'key');
+        return response($response);
     }
 
     /**

--- a/yeahcheese/app/Http/Kernel.php
+++ b/yeahcheese/app/Http/Kernel.php
@@ -7,28 +7,28 @@ use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 class Kernel extends HttpKernel
 {
-    /**
-     * The application's global HTTP middleware stack.
-     *
-     * These middleware are run during every request to your application.
-     *
-     * @var array
-     */
-    protected $middleware = [
+  /**
+   * The application's global HTTP middleware stack.
+   *
+   * These middleware are run during every request to your application.
+   *
+   * @var array
+   */
+  protected $middleware = [
     \App\Http\Middleware\TrustProxies::class,
     \Fruitcake\Cors\HandleCors::class,
     \App\Http\Middleware\CheckForMaintenanceMode::class,
     \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
     \App\Http\Middleware\TrimStrings::class,
     \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-    ];
+  ];
 
-    /**
-     * The application's route middleware groups.
-     *
-     * @var array
-     */
-    protected $middlewareGroups = [
+  /**
+   * The application's route middleware groups.
+   *
+   * @var array
+   */
+  protected $middlewareGroups = [
     'web' => [
       \App\Http\Middleware\EncryptCookies::class,
       \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
@@ -44,16 +44,16 @@ class Kernel extends HttpKernel
       'throttle:60,1',
       \Illuminate\Routing\Middleware\SubstituteBindings::class,
     ],
-    ];
+  ];
 
-    /**
-     * The application's route middleware.
-     *
-     * These middleware may be assigned to groups or used individually.
-     *
-     * @var array
-     */
-    protected $routeMiddleware = [
+  /**
+   * The application's route middleware.
+   *
+   * These middleware may be assigned to groups or used individually.
+   *
+   * @var array
+   */
+  protected $routeMiddleware = [
     'auth' => \App\Http\Middleware\Authenticate::class,
     'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
     'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
@@ -64,5 +64,6 @@ class Kernel extends HttpKernel
     'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
     'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-    ];
+    'auth-event' => \App\Http\Middleware\AuthenticateEvent::class,
+  ];
 }

--- a/yeahcheese/app/Http/Kernel.php
+++ b/yeahcheese/app/Http/Kernel.php
@@ -7,28 +7,28 @@ use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 class Kernel extends HttpKernel
 {
-  /**
-   * The application's global HTTP middleware stack.
-   *
-   * These middleware are run during every request to your application.
-   *
-   * @var array
-   */
-  protected $middleware = [
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array
+     */
+    protected $middleware = [
     \App\Http\Middleware\TrustProxies::class,
     \Fruitcake\Cors\HandleCors::class,
     \App\Http\Middleware\CheckForMaintenanceMode::class,
     \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
     \App\Http\Middleware\TrimStrings::class,
     \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
-  ];
+    ];
 
-  /**
-   * The application's route middleware groups.
-   *
-   * @var array
-   */
-  protected $middlewareGroups = [
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array
+     */
+    protected $middlewareGroups = [
     'web' => [
       \App\Http\Middleware\EncryptCookies::class,
       \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
@@ -44,16 +44,16 @@ class Kernel extends HttpKernel
       'throttle:60,1',
       \Illuminate\Routing\Middleware\SubstituteBindings::class,
     ],
-  ];
+    ];
 
-  /**
-   * The application's route middleware.
-   *
-   * These middleware may be assigned to groups or used individually.
-   *
-   * @var array
-   */
-  protected $routeMiddleware = [
+    /**
+     * The application's route middleware.
+     *
+     * These middleware may be assigned to groups or used individually.
+     *
+     * @var array
+     */
+    protected $routeMiddleware = [
     'auth' => \App\Http\Middleware\Authenticate::class,
     'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
     'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
@@ -65,5 +65,5 @@ class Kernel extends HttpKernel
     'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
     'auth-event' => \App\Http\Middleware\AuthenticateEvent::class,
-  ];
+    ];
 }

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -62,6 +62,9 @@ class AuthenticateEvent
         return $request;
     }
 
+    /**
+     * ログインユーザーに紐づくイベントであるかによってレスポンス内容を変化させる
+     */
     private function hasUserEvent($request, $event)
     {
         if ($event) {

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -51,7 +51,7 @@ class AuthenticateEvent
     private function withinResponseOrOutsideResponse($request, $user, $event)
     {
         if ($this->checkDeadline($event)) {
-            $path = $this->getPath($user, $event);
+            $path = $this->getPath($event);
             $opt = [
                 'errors' => null,
                 'status' => 200,
@@ -85,14 +85,9 @@ class AuthenticateEvent
     /**
      * ユーザーの種類に応じて、認証後の遷移先パスを変化させて返却
      */
-    private function getPath($user, $event)
+    private function getPath($event)
     {
-        $path = null;
-        if (is_null($user)) {
-            $path = '/event/' . $event->id;
-        } else {
-            $path = '/events/' . $event->id;
-        }
+        $path = '/events/event-' . $event->id;
         return $path;
     }
 }

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+
+class AuthenticateEvent
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        return $next($request);
+    }
+}

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -91,7 +91,7 @@ class AuthenticateEvent
         if (is_null($user)) {
             $path = '/event/' . $event->id;
         } else {
-            $path = '/event/' . $event->id;
+            $path = '/events/' . $event->id;
         }
         return $path;
     }

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -3,18 +3,97 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Auth;
+use App\Event;
+use Carbon\Carbon;
 
 class AuthenticateEvent
 {
-    /**
-     * Handle an incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
-     * @return mixed
-     */
     public function handle($request, Closure $next)
     {
+        $user = Auth::user();
+        $key = $request->key;
+        $event = Event::where('key', $key)->first();
+        $request = $this->getRequest($request, $user, $event);
         return $next($request);
+    }
+    /**
+     * ユーザーの種類とイベントの有無に応じて、レスポンス内容を変化させて返却
+     */
+    private function getRequest($request, $user, $event)
+    {
+        $request = $this->isValidkeyOrInvalidKey($request, $user, $event);
+        return $request;
+    }
+
+    /**
+     * 有効な認証キーか無効な認証キーかによってレスポンス内容を変化させて返却
+     */
+    private function isValidkeyOrInvalidKey($request, $user, $event)
+    {
+        $opt = null;
+        if (is_null($event)) {
+            $opt = [
+                'errors' => ['認証キーが間違っています'],
+                'status' => 406,
+                'key' => $request->key
+            ];
+            $request->merge($opt);
+        } else {
+            $request = $this->withinResponseOrOutsideResponse($request, $user, $event);
+        }
+        return $request;
+    }
+
+    /**
+     * 公開期限内か公開期限外かによってレスポンス内容を変化させて返却
+     */
+    private function withinResponseOrOutsideResponse($request, $user, $event)
+    {
+        if ($this->checkDeadline($event)) {
+            $path = $this->getPath($user, $event);
+            $opt = [
+                'errors' => null,
+                'status' => 200,
+                'event' => $event,
+                'path' => $path,
+            ];
+            $request->merge($opt);
+        } else {
+            $opt = [
+                'errors' => ['公開期限外のイベントです'],
+                'status' => 403,
+                'key' => $request->key,
+            ];
+            $request->merge($opt);
+        }
+        return $request;
+    }
+
+    /**
+     * 取得できたイベントが公開期限内であるかどうかの判定
+     */
+    private function checkDeadline($event)
+    {
+        $today = Carbon::now();
+        $start_date = $event->start_date;
+        $end_date = $event->end_date;
+        dd($today, $start_date, $end_date);
+        $within = $today->between($start_date, $end_date);
+        return $within;
+    }
+
+    /**
+     * ユーザーの種類に応じて、認証後の遷移先パスを変化させて返却
+     */
+    private function getPath($user, $event)
+    {
+        $path = null;
+        if (is_null($user)) {
+            $path = '/event/' . $event->id;
+        } else {
+            $path = '/event/' . $event->id;
+        }
+        return $path;
     }
 }

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -22,19 +22,19 @@ class AuthenticateEvent
      */
     private function getRequest($request, $user, $event)
     {
-        $request = $this->isValidkeyOrInvalidKey($request, $user, $event);
+        $request = $this->isValidKey($request, $user, $event);
         return $request;
     }
 
     /**
      * 有効な認証キーか無効な認証キーかによってレスポンス内容を変化させて返却
      */
-    private function isValidkeyOrInvalidKey($request, $user, $event)
+    private function isValidKey($request, $user, $event)
     {
         if (is_null($event)) {
             $request = $this->createErrorResponse($request, ['認証キーが間違っています'], 406);
         } else {
-            $request = $this->withinResponseOrOutsideResponse($request, $user, $event);
+            $request = $this->withinDeadline($request, $user, $event);
         }
         return $request;
     }
@@ -42,7 +42,7 @@ class AuthenticateEvent
     /**
      * 公開期限内か公開期限外かによってレスポンス内容を変化させて返却
      */
-    private function withinResponseOrOutsideResponse($request, $user, $event)
+    private function withinDeadline($request, $user, $event)
     {
         // ログイン済みユーザーは公開期限に関わらず成功
         // ユーザーが保持していないイベントにアクセスしようとした場合は403エラーを飛ばす

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -31,7 +31,6 @@ class AuthenticateEvent
      */
     private function isValidkeyOrInvalidKey($request, $user, $event)
     {
-        $opt = null;
         if (is_null($event)) {
             $request = $this->createErrorResponse($request, ['認証キーが間違っています'], 406);
         } else {

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -83,7 +83,7 @@ class AuthenticateEvent
     }
 
     /**
-     * ユーザーの種類に応じて、認証後の遷移先パスを変化させて返却
+     * 認証後の遷移先パスを変化させて返却
      */
     private function getPath($event)
     {

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -62,7 +62,7 @@ class AuthenticateEvent
         } else {
             $opt = [
                 'errors' => ['公開期限外のイベントです'],
-                'status' => 403,
+                'status' => 422,
                 'key' => $request->key,
             ];
             $request->merge($opt);

--- a/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
+++ b/yeahcheese/app/Http/Middleware/AuthenticateEvent.php
@@ -78,7 +78,6 @@ class AuthenticateEvent
         $today = Carbon::now();
         $start_date = $event->start_date;
         $end_date = $event->end_date;
-        dd($today, $start_date, $end_date);
         $within = $today->between($start_date, $end_date);
         return $within;
     }

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -109,16 +109,19 @@ export default {
     setLoding("イベントのkeyを照合しています")
     let param = { key: key }
     // ! 後で消す！！！！！
-    const tmpResponse = httpWithToken.post(Route.EVENTS_AUTH, param);
-    console.log('api.response', tmpResponse);
-    // .then(
-    // res => {
-    //   const key = "event-" + res.data.id
-    //   setToken(res.data.key, key);
-    //   setApiStatus(res.status);
-    //   return res.data;
-    // }
-    // , onError)
+    const response = httpWithToken.post(Route.EVENTS_AUTH, param)
+      .then(
+        res => {
+          let response = res.data;
+          const status = response.status;
+          const key = response.id ? "event-" + response.id : null;
+          if (key) {
+            setToken(res.data.data.key, key);
+          }
+          setApiStatus(status);
+          return response;
+        })
+    return response;
   },
 
   // イベント一覧

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -108,15 +108,14 @@ export default {
   eventAuth(key) {
     setLoding("イベントのkeyを照合しています")
     let param = { key: key }
-    // ! 後で消す！！！！！
     const response = httpWithToken.post(Route.EVENTS_AUTH, param)
       .then(
         res => {
           let response = res.data;
           const status = response.status;
-          const key = response.id ? "event-" + response.id : null;
+          const key = response.data ? "event-" + response.data.id : null;
           if (key) {
-            setToken(res.data.data.key, key);
+            setToken(response.data.key, key);
           }
           setApiStatus(status);
           return response;

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -108,14 +108,17 @@ export default {
   eventAuth(key) {
     setLoding("イベントのkeyを照合しています")
     let param = { key: key }
-    return httpWithToken.post(Route.EVENTS_AUTH, param).then(
-      res => {
-        const key = "event-" + res.data.id
-        setToken(res.data.key, key);
-        setApiStatus(res.status);
-        return res.data;
-      }
-      , onError)
+    // ! 後で消す！！！！！
+    const tmpResponse = httpWithToken.post(Route.EVENTS_AUTH, param);
+    console.log('api.response', tmpResponse);
+    // .then(
+    // res => {
+    //   const key = "event-" + res.data.id
+    //   setToken(res.data.key, key);
+    //   setApiStatus(res.status);
+    //   return res.data;
+    // }
+    // , onError)
   },
 
   // イベント一覧

--- a/yeahcheese/resources/js/pages/index.vue
+++ b/yeahcheese/resources/js/pages/index.vue
@@ -43,7 +43,6 @@ export default {
         return false;
       }
       let response = await api.eventAuth(this.authKey);
-      response = response;
       if (this.isApiSuccess) {
         this.$router.push({ path: response.path });
       } else {

--- a/yeahcheese/resources/js/pages/index.vue
+++ b/yeahcheese/resources/js/pages/index.vue
@@ -42,11 +42,12 @@ export default {
         this.validationMessages.push("認証キーを入力してください");
         return false;
       }
-      const response = await api.eventAuth(this.authKey);
+      let response = await api.eventAuth(this.authKey);
+      response = response;
       if (this.isApiSuccess) {
-        this.$router.push({ path: `/events/event-${response.id}` });
+        this.$router.push({ path: response.path });
       } else {
-        this.validationMessages.push("認証キーが間違っています");
+        this.validationMessages.push(...response.errors);
       }
     },
     delValidation() {


### PR DESCRIPTION
## やったこと
- 公開期限外のイベント閲覧を、ゲストユーザーのみができないようにした（ログイン済みユーザーの場合は閲覧可能）
- ログイン済みユーザーがイベント詳細を見る場合、そのユーザーが保持しているイベントかどうかでレスポンス内容を変化させた（権限がない場合は別ページに飛ばす）

## 考えどころ
- ログインユーザーが認証キーを入力し、照合された後に飛ばされるページでは「編集」「削除」等ができるため、ログインユーザーが保持しているイベントかどうかを判別したのちに権限がない場合は403エラーページに飛ばすようにした点
  - つまり、ログインしているユーザーが他のユーザーのイベントを認証ページから閲覧したい場合は、一度ログアウトしなければいけない

### 認証キーの間違い
![スクリーンショット 2020-05-26 10 46 17](https://user-images.githubusercontent.com/54382187/82854880-ac910880-9f44-11ea-9ae4-a1828e93df78.png)

### 公開期限外
![スクリーンショット 2020-05-26 10 45 56](https://user-images.githubusercontent.com/54382187/82854897-badf2480-9f44-11ea-86ec-bf52c141d7fc.png)

### 公開期限内（ゲストユーザー）
![スクリーンショット 2020-05-26 10 46 33](https://user-images.githubusercontent.com/54382187/82854910-c7637d00-9f44-11ea-8c0e-4779db6b1102.png)

### 公開期限内もしくは公開期限外（ログインユーザー）
![スクリーンショット 2020-05-26 11 34 52](https://user-images.githubusercontent.com/54382187/82854973-f1b53a80-9f44-11ea-8e9d-a5a30cc9e726.png)

### 閲覧権限がないイベント（ログインユーザー）
![スクリーンショット 2020-05-26 11 30 50](https://user-images.githubusercontent.com/54382187/82855018-0f829f80-9f45-11ea-931f-9d987f6e3891.png)
