### PR TITLE
Feature/warning at page transition frontend（ページリロード・ページ遷移時に警告モーダルを表示する）

### DIFF
--- a/yeahcheese/resources/js/components/AlertModal.vue
+++ b/yeahcheese/resources/js/components/AlertModal.vue
@@ -1,0 +1,112 @@
+<template>
+  <div id="alert-modal" v-show="isShow">
+    <div class="modal-wrapper">
+      <div class="modal-disp">
+        <div class="float-right-box">
+          <button class="close-modal-btn" @click="closeModal">
+            <span>✖️</span>
+          </button>
+        </div>
+        <div class="alert-text-box">
+          <slot name="alert-text">
+            <p>ここにアラートさせたい文章を追加してください。</p>
+          </slot>
+        </div>
+        <div class="h-center-box">
+          <slot name="additional">
+            <button>ボタン</button>
+          </slot>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    isShow: {
+      type: Boolean,
+      default: false
+    }
+  },
+  methods: {
+    closeModal() {
+      this.$emit("close-modal");
+    }
+  }
+};
+</script>
+
+<style scoped>
+#alert-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(10, 10, 10, 0.7);
+  z-index: 999999;
+}
+#alert-modal .modal-wrapper {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+#alert-modal .modal-wrapper .modal-disp {
+  position: relative;
+  width: 80vw;
+  padding: 8px;
+  background-color: whitesmoke;
+  border-radius: 5px;
+}
+#alert-modal .modal-wrapper .modal-disp::after {
+  display: block;
+  content: "";
+  clear: both;
+}
+#alert-modal .alert-text-box {
+  padding: 32px 0 16px;
+}
+#alert-modal .h-center-box {
+  display: flex;
+  justify-content: center;
+}
+#alert-modal .float-right-box::after {
+  content: "";
+  clear: both;
+}
+#alert-modal .close-modal-btn {
+  float: right;
+  padding: 0;
+  width: 50px;
+  height: 50px;
+  line-height: 50px;
+  text-align: center;
+}
+#alert-modal .close-modal-btn span {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+}
+/**
+ボタンや文字の大きさとかはこっちでコントロールした方が良いかも
+*/
+p {
+  text-align: center;
+  font-size: 1.3rem;
+}
+button {
+  width: 25%;
+  margin: 0 16px;
+  padding: 16px 8px;
+  font-size: 1.25rem;
+  outline: none;
+  border: 1px solid gray;
+  border-radius: 5px;
+  cursor: pointer;
+}
+</style>

--- a/yeahcheese/resources/js/components/AlertModal.vue
+++ b/yeahcheese/resources/js/components/AlertModal.vue
@@ -3,7 +3,7 @@
     <div class="modal-wrapper">
       <div class="modal-disp">
         <div class="float-right-box">
-          <button class="close-modal-btn" @click="closeModal">
+          <button class="close-modal-btn">
             <span>✖️</span>
           </button>
         </div>
@@ -28,11 +28,6 @@ export default {
     isShow: {
       type: Boolean,
       default: false
-    }
-  },
-  methods: {
-    closeModal() {
-      this.$emit("close-modal");
     }
   }
 };

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -82,7 +82,10 @@ export default {
         start_date: "",
         end_date: ""
       },
-      validationMessages: []
+      validationMessages: [],
+      isUnsave: false,
+      openAlertModel: false,
+      transitionPath: null
     };
   },
   computed: {
@@ -112,6 +115,15 @@ export default {
       return response;
     }
   },
+  watch: {
+    eventForm: {
+      handler: function() {
+        // !入力があった場合はセーブしていない状態に変更
+        this.isUnsave = true;
+      },
+      deep: true
+    }
+  },
   methods: {
     ...mapActions("events", ["eventUpdate"]),
     async updateEvent() {
@@ -138,9 +150,13 @@ export default {
       this.validationMessages = errors;
     },
     registerReloadEvent() {
+      console.log("ok");
+      const self = this;
       window.addEventListener("beforeunload", function(e) {
-        e.preventDefault();
-        e.returnValue = "chotomate";
+        if (self.isUnsave) {
+          e.preventDefault();
+          e.returnValue = "chotomate";
+        }
       });
     }
   },
@@ -149,6 +165,16 @@ export default {
     await this.$store.dispatch("events/getEventsAndPhotosIfNotExits", event_id);
     this.eventForm = this.getEventForId(event_id);
     this.registerReloadEvent(); //リロード対策
+  },
+  beforeRouteLeave(to, from, next) {
+    //!保存していないデータがある場合
+    if (this.isUnsave) {
+      //!モーダルを表示させる
+      this.openAlertModel = true;
+      this.transitionPath = to.fullPath;
+    } else {
+      next();
+    }
   }
 };
 </script>

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -154,7 +154,6 @@ export default {
       // ! watchで受け取った変更後の初期値(oldData)が空
       // ! => 初回だけfalseが返るメソッド
       // ! => 以降はnewDataもoldDataも同じ値のため、常にtrueを返す
-      console.log("起動");
       const {
         name: newName,
         start_date: newStartDate,

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="event-edit">
-    <!-- <alert-modal :isShow="openAlertModel" :to="transitionPath"></alert-modal> -->
+    <!-- <alert-modal :isShow="openAlertModel"></alert-modal> -->
     <router-link
       class="btn btn-outline-info mb-5"
       :to="{ name: 'eventShow', params: { id: eventForm.id } }"
@@ -178,14 +178,16 @@ export default {
     this.registerReloadEvent(); //リロード対策
   },
   beforeRouteLeave(to, from, next) {
-    //!保存していないデータがある場合
     if (this.isUnsave) {
-      //!モーダルを表示させる
       this.openAlertModel = true;
-      this.transitionPath = to.fullPath;
+      this.transitionPath = to.fullPath; // !保存せずに移動するとき使用
     } else {
       next();
     }
+  },
+  beforeDestroy() {
+    // TODO: 保存フラグを確認して、trueなら入力値を更新するapiを起動させる
+    // TODO:                   falseならフルパスを取得してRoutePush
   }
 };
 </script>

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -1,10 +1,10 @@
 <template>
   <div id="event-edit">
-    <AlertModel :isShow="openAlertModel" @close-modal="closeModal">
+    <AlertModal :isShow="openAlertModal" @close-modal="closeModal">
       <p slot="alert-text">編集内容を保存していません</p>
       <button class="modal-btn save-btn" slot="additional" @click="saveAndMove(true)">⓵変更を保存して移動</button>
       <button class="modal-btn unsave-btn" slot="additional" @click="saveAndMove(false)">②変更を保存せずに移動</button>
-    </AlertModel>
+    </AlertModal>
     <router-link
       class="btn btn-outline-info mb-5"
       :to="{ name: 'eventShow', params: { id: eventForm.id } }"
@@ -54,13 +54,13 @@
 import { mapGetters, mapActions } from "vuex";
 import validationMessages from "../components/validationMessages";
 import PreviewAndSavePhoto from "../components/PreviewAndSavePhoto";
-import AlertModel from "../components/AlertModal";
+import AlertModal from "../components/AlertModal";
 export default {
   name: "EventEdit",
   components: {
     validationMessages,
     PreviewAndSavePhoto,
-    AlertModel
+    AlertModal
   },
   data() {
     return {
@@ -72,7 +72,7 @@ export default {
       },
       validationMessages: [],
       isUnsave: false,
-      openAlertModel: false,
+      openAlertModal: false,
       transitionPath: "",
       wantSave: false
     };

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -1,6 +1,10 @@
 <template>
   <div id="event-edit">
-    <!-- <alert-modal :isShow="openAlertModel"></alert-modal> -->
+    <AlertModel :isShow="openAlertModel" @close-modal="closeModal">
+      <p slot="alert-text">編集内容を保存していません</p>
+      <button class="modal-btn save-btn" slot="additional" @click="saveAndMove(true)">⓵変更を保存して移動</button>
+      <button class="modal-btn unsave-btn" slot="additional" @click="saveAndMove(false)">②変更を保存せずに移動</button>
+    </AlertModel>
     <router-link
       class="btn btn-outline-info mb-5"
       :to="{ name: 'eventShow', params: { id: eventForm.id } }"
@@ -50,12 +54,13 @@
 import { mapGetters, mapActions } from "vuex";
 import validationMessages from "../components/validationMessages";
 import PreviewAndSavePhoto from "../components/PreviewAndSavePhoto";
-// import AlertModel from "../components/AlertModal";
+import AlertModel from "../components/AlertModal";
 export default {
   name: "EventEdit",
   components: {
     validationMessages,
-    PreviewAndSavePhoto
+    PreviewAndSavePhoto,
+    AlertModel
   },
   data() {
     return {
@@ -201,5 +206,16 @@ export default {
 }
 #event-edit button {
   margin-bottom: 80px;
+}
+.modal-btn {
+  color: white;
+  margin-top: 24px;
+  margin-bottom: 0;
+}
+.save-btn {
+  background-color: dodgerblue;
+}
+.unsave-btn {
+  background-color: indianred;
 }
 </style>

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -134,12 +134,19 @@ export default {
     },
     pushErrors(errors) {
       this.validationMessages = errors;
+    },
+    registerReloadEvent() {
+      window.addEventListener("beforeunload", function(e) {
+        e.preventDefault();
+        e.returnValue = "chotomate";
+      });
     }
   },
   async created() {
     let event_id = this.$route.params["id"];
     await this.$store.dispatch("events/getEventsAndPhotosIfNotExits", event_id);
     this.eventForm = this.getEventForId(event_id);
+    this.registerReloadEvent(); //リロード対策
   }
 };
 </script>

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -73,7 +73,7 @@ export default {
       validationMessages: [],
       isUnsave: false,
       openAlertModel: false,
-      transitionPath: null,
+      transitionPath: "",
       wantSave: false
     };
   },
@@ -133,11 +133,15 @@ export default {
       };
       const response = await this.eventUpdate(payload);
       if (this.isSuccess) {
-        this.initFlag();
-        this.$router.push({
-          name: "eventShow",
-          params: { id: this.eventForm.id }
-        });
+        if (this.transitionPath === "") {
+          this.initFlags(); // ! 通常の更新ならば、全てのフラグをオフにして普通に遷移させる
+          this.$router.push({
+            name: "eventShow",
+            params: { id: this.eventForm.id }
+          });
+        } else {
+          this.moveOtherPage(this.transitionPath);
+        }
       } else {
         this.validationMessages = response;
       }
@@ -178,10 +182,11 @@ export default {
     },
     closeModal() {
       this.openAlertModel = false;
-      this.transitionPath = null;
+      this.transitionPath = "";
       this.wantSave = null;
     },
     saveAndMove(isSave) {
+      //*モーダルのボタン
       this.wantSave = isSave;
       this.openAlertModel = false;
       this.moveOtherPage(this.transitionPath);
@@ -193,10 +198,11 @@ export default {
       if (this.canMove(path)) {
         this.isUnsave = false;
         this.$router.push(path);
-        this.transitionPath = "";
+        return true;
       }
+      return false;
     },
-    initFlag() {
+    initFlags() {
       this.isUnsave = false;
       this.openAlertModel = false;
       this.transitionPath = null;

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="event-edit">
-    <AlertModal :isShow="openAlertModal" @close-modal="closeModal">
+    <AlertModal :isShow="openAlertModal" @click.native="closeModal">
       <p slot="alert-text">編集内容を保存していません</p>
       <button class="modal-btn save-btn" slot="additional" @click="saveAndMove(true)">⓵変更を保存して移動</button>
       <button class="modal-btn unsave-btn" slot="additional" @click="saveAndMove(false)">②変更を保存せずに移動</button>
@@ -181,14 +181,14 @@ export default {
       );
     },
     closeModal() {
-      this.openAlertModel = false;
+      this.openAlertModal = false;
       this.transitionPath = "";
       this.wantSave = null;
     },
     saveAndMove(isSave) {
       //*モーダルのボタン
       this.wantSave = isSave;
-      this.openAlertModel = false;
+      this.openAlertModal = false;
       this.moveOtherPage(this.transitionPath);
     },
     canMove(path) {
@@ -204,7 +204,7 @@ export default {
     },
     initFlags() {
       this.isUnsave = false;
-      this.openAlertModel = false;
+      this.openAlertModal = false;
       this.transitionPath = null;
       this.wantSave = false;
     }
@@ -214,12 +214,11 @@ export default {
     await this.$store.dispatch("events/getEventsAndPhotosIfNotExits", event_id);
     this.eventForm = this.getEventForId(event_id); //!多分ここでストアのイベント情報を入れているせいか、eventFormの編集履歴がリンクを踏んだ先に反映されてしまっている
     this.registerReloadEvent(); //リロード対策
-    console.log(this.eventForm);
     this.base_event = JSON.parse(JSON.stringify(this.eventForm));
   },
   beforeRouteLeave(to, from, next) {
     if (this.isUnsave) {
-      this.openAlertModel = true;
+      this.openAlertModal = true;
       this.transitionPath = to.fullPath;
       next(false);
     } else {

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -47,23 +47,6 @@
 </template>
 
 <script>
-/**
- * [イベント編集] - イベント情報の更新と写真の追加・削除が可能
- * ? 必要な情報
- *  * 単一のイベント情報
- *   * created内でstoreにあるeventsからルートパラメータのイベントを取得
- *   * 更新時に参照するため、eventに格納
- *  * イベントに紐づく写真情報
- *   * イベントのリレーションから取得
- *   * 削除時に参照するため、photosに格納
- * ? 表示させる情報
- *  * イベント名
- *  * 公開開始日
- *  * 公開終了日
- *  * イベントに紐づく写真(今は仮でpathだけ表示)
- * ! Laravel側で修正が必要かもしれない部分
- * ! * バリデーションエラーの場合、送信されてきたイベント情報をオウム返しする（これをVueで受け取り、再度表示させる）
- */
 import { mapGetters, mapActions } from "vuex";
 import validationMessages from "../components/validationMessages";
 import PreviewAndSavePhoto from "../components/PreviewAndSavePhoto";

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -133,6 +133,7 @@ export default {
       };
       const response = await this.eventUpdate(payload);
       if (this.isSuccess) {
+        this.initFlag();
         this.$router.push({
           name: "eventShow",
           params: { id: this.eventForm.id }
@@ -194,6 +195,12 @@ export default {
         this.$router.push(path);
         this.transitionPath = "";
       }
+    },
+    initFlag() {
+      this.isUnsave = false;
+      this.openAlertModel = false;
+      this.transitionPath = null;
+      this.wantSave = false;
     }
   },
   async created() {

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -100,9 +100,15 @@ export default {
   },
   watch: {
     eventForm: {
-      handler: function() {
-        // !入力があった場合はセーブしていない状態に変更
-        this.isUnsave = true;
+      handler: function(newFormData, oldFormData) {
+        // セーブしていない、尚且つデータに変更があった場合のみ、アンセーブにする
+        // 一度isUnsaveをtrueにすれば、isInitDataは起動されない
+        if (
+          this.isUnsave === false &&
+          this.isInitData(newFormData, oldFormData)
+        ) {
+          this.isUnsave = true;
+        }
       },
       deep: true
     }
@@ -141,6 +147,29 @@ export default {
           e.returnValue = "chotomate";
         }
       });
+    },
+    isInitData(newData, oldData) {
+      // ! watchで受け取った変更前と変更後のデータを比較
+      // ! watchで受け取った変更前の初期値(newData)がイベント情報
+      // ! watchで受け取った変更後の初期値(oldData)が空
+      // ! => 初回だけfalseが返るメソッド
+      // ! => 以降はnewDataもoldDataも同じ値のため、常にtrueを返す
+      console.log("起動");
+      const {
+        name: newName,
+        start_date: newStartDate,
+        end_date: newEndDate
+      } = newData;
+      const {
+        name: oldName,
+        start_date: oldStartDate,
+        end_date: oldEndDate
+      } = oldData;
+      return (
+        oldName === newName ||
+        oldStartDate === newStartDate ||
+        oldEndDate == newEndDate
+      );
     }
   },
   async created() {

--- a/yeahcheese/resources/js/pages/EventEdit.vue
+++ b/yeahcheese/resources/js/pages/EventEdit.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="event-edit">
+    <!-- <alert-modal :isShow="openAlertModel" :to="transitionPath"></alert-modal> -->
     <router-link
       class="btn btn-outline-info mb-5"
       :to="{ name: 'eventShow', params: { id: eventForm.id } }"
@@ -66,6 +67,7 @@
 import { mapGetters, mapActions } from "vuex";
 import validationMessages from "../components/validationMessages";
 import PreviewAndSavePhoto from "../components/PreviewAndSavePhoto";
+// import AlertModel from "../components/AlertModal";
 export default {
   name: "EventEdit",
   components: {


### PR DESCRIPTION
## やったこと
- イベント情報に何かしら変化があった際に、リロード・遷移時に警告モーダルを表示するようにした
  - リロードの場合、chrome標準のアラート？が出るように
  - ページ遷移・ブラウザバックの場合、モーダルコンポーネントを表示
    - 罰ボタンを押すと、モーダルを閉じてそのまま編集画面に留まる
    - 変更を保存して...を押すと、編集内容を保存したのちにユーザーが指定したパスに遷移
    - 変更を保存せず...を押すと、編集内容を保存せずにユーザーが指定したパスに遷移
    - なお、イベント情報に変更がない場合は通常通りリロード・遷移させるようにした

### ページ更新時
![スクリーンショット 2020-05-27 15 50 27](https://user-images.githubusercontent.com/54382187/82987023-d8d68300-a031-11ea-815a-1cedf4a3d2e4.png)

### リンクを踏む・ブラウザバック等のページ遷移時
![スクリーンショット 2020-05-27 15 50 40](https://user-images.githubusercontent.com/54382187/82987068-e7bd3580-a031-11ea-802b-a1e592f62018.png)

### 気づいたこと
- イベント情報を編集し、更新しない状態でイベント一覧に戻ると、編集内容が反映されてしまっている
- ページを更新すると元の状態に戻るため、vuex側に反映されているのだと思う

#### 編集中の状態で
![スクリーンショット 2020-05-27 15 55 21](https://user-images.githubusercontent.com/54382187/82987484-8d70a480-a032-11ea-9583-01320c17cf01.png)

#### イベント一覧のリンクを踏むと
![スクリーンショット 2020-05-27 15 55 31](https://user-images.githubusercontent.com/54382187/82987493-91042b80-a032-11ea-9e4f-e2960d56c68d.png)

#### 更新すると
![スクリーンショット 2020-05-27 15 57 50](https://user-images.githubusercontent.com/54382187/82987651-da547b00-a032-11ea-9d15-c2f0a29cc10a.png)


- ここら辺？
![スクリーンショット 2020-05-27 14 37 47](https://user-images.githubusercontent.com/54382187/82987318-497d9f80-a032-11ea-9899-405e11bfaa47.png)

 ### 解決しました
- ストアから引っ張ってきたデータをディープコピーして、保存せずに移動した際にコピーした元の値でストアのデータを上書きするようにした