### PR TITLE
Feature/photos favorites for login user frontend（お気に入り機能のフロントエンド）

### DIFF
--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -187,4 +187,23 @@ export default {
     setLoding("イベントの写真を削除しています")
     return httpWithToken.delete(Route.PHOTOS_DESTROY(id, photo_id)).then(onSuccess, onError);
   },
+
+  // イベントの写真 お気に入り
+  // 必要 param eventのid , photoのid
+  // 返却値 まだ分からない
+  // イベントに紐付く写真をお気に入り
+  eventPhotosAddLikes(id, photo_id) {
+    // setLoding("イベントの写真をお気に入り登録しています")
+    // putかpostかpatchかはバックエンド側と合わせる
+    return httpWithToken.put(Route.PHOTOS_ADD_LIKES(id, photo_id)).then(onSuccess, onError);
+  },
+
+  // イベントの写真 お気に入り
+  // 必要 param eventのid , photoのid
+  // 返却値 まだ分からない
+  // イベントに紐付く写真をお気に入り
+  eventPhotosDeleteLikes(id, photo_id) {
+    // setLoding("イベントの写真をお気に入り＊＊＊しています")
+    return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES(id, photo_id)).then(onSuccess, onError);
+  }
 };

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -185,15 +185,16 @@ export default {
     return httpWithToken.delete(Route.PHOTOS_DESTROY(id, photo_id)).then(onSuccess, onError);
   },
   photoLikesIndex() {
+    setLoding("お気に入りした写真を取得しています")
     return httpWithToken.get(Route.PHOTOS_LIKES_INDEX).then(onSuccess, onError);
   },
   // イベントの写真 お気に入り登録
-  photoLikesStore() {
+  photoLikesStore(likesId) {
     return httpWithToken.post(Route.PHOTOS_ADD_LIKES, likesId).then(onSuccess, onError);
   },
 
   // イベントの写真 お気に入り削除
-  photoLikesDestroy() {
+  photoLikesDestroy(dislikesId) {
     return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES, dislikesId).then(onSuccess, onError);
   }
 };

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -190,11 +190,14 @@ export default {
   },
   // イベントの写真 お気に入り登録
   photoLikesStore(likesId) {
+    setLoding("お気に入りしています")
     return httpWithToken.post(Route.PHOTOS_ADD_LIKES, likesId).then(onSuccess, onError);
   },
 
   // イベントの写真 お気に入り削除
   photoLikesDestroy(dislikesId) {
-    return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES, dislikesId).then(onSuccess, onError);
+    setLoding("お気に入りを解除しています")
+    httpWithToken.defaults.headers['X-HTTP-Method-Override'] = 'DELETE';
+    return httpWithToken.post(Route.PHOTOS_DELETE_LIKES, dislikesId).then(onSuccess, onError);
   }
 };

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -204,6 +204,7 @@ export default {
   // イベントに紐付く写真をお気に入り
   eventPhotosDeleteLikes(id, photo_id) {
     // setLoding("イベントの写真をお気に入り＊＊＊しています")
+    // DELETEは写真削除で使用しているため、uri変更する必要あり（...photos/:id/likesとか？）
     return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES(id, photo_id)).then(onSuccess, onError);
   }
 };

--- a/yeahcheese/resources/js/api.js
+++ b/yeahcheese/resources/js/api.js
@@ -179,32 +179,21 @@ export default {
     return httpWithToken.post(Route.PHOTOS_STORE(id), photo).then(onSuccess, onError);
   },
 
-  // イベントの写真 削除
-  // 必要 param eventのid , photoのid
-  // 返却値 写真の json配列
-  // イベントに紐付く写真を削除
+  // イベントの写真 
   eventPhotosDestroy(id, photo_id) {
     setLoding("イベントの写真を削除しています")
     return httpWithToken.delete(Route.PHOTOS_DESTROY(id, photo_id)).then(onSuccess, onError);
   },
-
-  // イベントの写真 お気に入り
-  // 必要 param eventのid , photoのid
-  // 返却値 まだ分からない
-  // イベントに紐付く写真をお気に入り
-  eventPhotosAddLikes(id, photo_id) {
-    // setLoding("イベントの写真をお気に入り登録しています")
-    // putかpostかpatchかはバックエンド側と合わせる
-    return httpWithToken.put(Route.PHOTOS_ADD_LIKES(id, photo_id)).then(onSuccess, onError);
+  photoLikesIndex() {
+    return httpWithToken.get(Route.PHOTOS_LIKES_INDEX).then(onSuccess, onError);
+  },
+  // イベントの写真 お気に入り登録
+  photoLikesStore() {
+    return httpWithToken.post(Route.PHOTOS_ADD_LIKES, likesId).then(onSuccess, onError);
   },
 
-  // イベントの写真 お気に入り
-  // 必要 param eventのid , photoのid
-  // 返却値 まだ分からない
-  // イベントに紐付く写真をお気に入り
-  eventPhotosDeleteLikes(id, photo_id) {
-    // setLoding("イベントの写真をお気に入り＊＊＊しています")
-    // DELETEは写真削除で使用しているため、uri変更する必要あり（...photos/:id/likesとか？）
-    return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES(id, photo_id)).then(onSuccess, onError);
+  // イベントの写真 お気に入り削除
+  photoLikesDestroy() {
+    return httpWithToken.delete(Route.PHOTOS_DELETE_LIKES, dislikesId).then(onSuccess, onError);
   }
 };

--- a/yeahcheese/resources/js/components/CommonHeader.vue
+++ b/yeahcheese/resources/js/components/CommonHeader.vue
@@ -25,6 +25,9 @@
               <span id="logout-btn" class="text-primary" @click="logout">ログアウト</span>
             </li>
             <li class="nav-item mr-3">
+              <router-link :to="{ path: '/photos/favorite' }">お気に入り写真一覧</router-link>
+            </li>
+            <li class="nav-item mr-3">
               <span class="text-secondary">{{ user.name }}さんがログイン中</span>
             </li>
           </template>

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -49,6 +49,7 @@
                     v-if="isMyEvent"
                   ></i>
                   <i
+                    v-if="isLogin"
                     class="fa fa-gratipay photo-likes-icon"
                     :class="likesClass(photos[preview_index])"
                     @click="toggleLikesIcon(photos[preview_index])"

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -72,7 +72,7 @@
 
 <script>
 import api from "../api";
-import { mapGetters } from "vuex";
+import { mapGetters, mapActions } from "vuex";
 import scrollControllable from "../mixins/scrollControllable";
 export default {
   props: {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -1,26 +1,33 @@
 <template>
   <div>
-    <div id="img-thumbnail" class="d-flex justify-content-between flex-wrap mb-5 img-area">
-      <div
-        class="img-thumbnail-wrap"
-        v-show="photos.length"
-        v-for=" (image, index) in photos"
-        :key="image.id"
-        :class="imgThumbnailSize"
+    <div>
+      <transition-group
+        id="img-thumbnail"
+        class="d-flex justify-content-between flex-wrap mb-5 img-area"
+        name="fade"
+        mode="out-in"
       >
-        <img
-          :alt="alt(image.id)"
-          :src="image.image_path"
-          class="img-thumbnail mb-2 bg-white"
-          @click="openPreview(index)"
-        />
-        <i
-          v-if="isLogin"
-          class="fa fa-gratipay photo-likes-icon thumbnail"
-          :class="likesClass(image)"
-          @click="toggleLikesIcon(image)"
-        ></i>
-      </div>
+        <div
+          class="img-thumbnail-wrap"
+          v-show="photos.length"
+          v-for=" (image, index) in photos"
+          :key="image.id"
+          :class="imgThumbnailSize"
+        >
+          <img
+            :alt="alt(image.id)"
+            :src="image.image_path"
+            class="img-thumbnail mb-2 bg-white"
+            @click="openPreview(index)"
+          />
+          <i
+            v-if="isLogin"
+            class="fa fa-gratipay photo-likes-icon thumbnail"
+            :class="likesClass(image)"
+            @click="toggleLikesIcon(image)"
+          ></i>
+        </div>
+      </transition-group>
       <p v-show="!photos.length">写真はまだありません</p>
     </div>
     <div class="wrap" v-if="preview && photos.length > 0" @click="preview=''">
@@ -191,7 +198,7 @@ export default {
   },
   beforeDestroy() {
     const user_id = this.user.id;
-  }
+  },
   mixins: [scrollControllable]
 };
 </script>
@@ -348,5 +355,13 @@ export default {
   max-height: 88%;
   width: 88%;
   padding: 21px;
+}
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+.fade-enter-active,
+.fade-leave-active {
+  transition: all 0.5s;
 }
 </style>

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -16,8 +16,8 @@
         />
         <i
           class="fa fa-gratipay photo-likes-icon thumbnail"
-          :class="likesClasses(image.id)"
-          @click="toggleLikesIcon(image.id)"
+          :class="likesClass(image)"
+          @click="toggleLikesIcon(image)"
         ></i>
       </div>
       <p v-show="!photos.length">写真はまだありません</p>
@@ -42,8 +42,8 @@
                   ></i>
                   <i
                     class="fa fa-gratipay photo-likes-icon"
-                    :class="likesClass"
-                    @click="toggleLikesIcon(photos[preview_index].id)"
+                    :class="likesClass(photos[preview_index])"
+                    @click="toggleLikesIcon(photos[preview_index])"
                   ></i>
                   <a
                     :href="this.photos[preview_index].image_path"
@@ -92,10 +92,7 @@ export default {
   data() {
     return {
       preview: "",
-      preview_index: "",
-      isLikedIcon: null, //お気に入りのボタンが一度でも押されたかどうかのフラグ
-      likesPreviewPhotoId: null, //プレビュー用のid収納
-      likesPhotoIds: [] //一覧用のid収納
+      preview_index: ""
     };
   },
   computed: {
@@ -122,13 +119,10 @@ export default {
       return "img-thumbnail-size" + this.selectedColumns;
     },
     likesClass() {
-      if (
-        this.isLikedIcon !== null &&
-        this.likesPhotoIds.includes(this.likesPreviewPhotoId)
-      ) {
-        return { likes: true };
-      }
-      return "";
+      // ! ステートが変更されれば自動的に変化する
+      return photo => {
+        return { likes: photo.is_favorite };
+      };
     }
   },
   methods: {
@@ -149,21 +143,10 @@ export default {
         this.preview_index = "";
       }
     },
-    likesClasses(photo_id) {
-      return { likes: this.likesPhotoIds.includes(photo_id) };
-    },
-    toggleLikesIcon(photo_id) {
-      this.isLikedIcon =
-        this.isLikedIcon === null || this.isLikedIcon === false ? true : false;
-      // TODO: event_idとphoto_idを保持しておく
-      this.likesPreviewPhotoId = photo_id;
-      if (!this.likesPhotoIds.includes(photo_id)) {
-        this.likesPhotoIds.push(photo_id);
-      } else {
-        const idx = this.likesPhotoIds.findIndex(id => id === photo_id);
-        this.likesPhotoIds.splice(idx, 1);
-      }
-      console.log("お気に入りする登録もの", this.likesPhotoIds);
+    toggleLikesIcon(photo) {
+      const photo_id = photo.id;
+      const request_type = photo.is_favorite ? "DELETE" : "POST";
+      // TODO: アクション起動
     },
     initData() {
       this.preview = "";

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -84,7 +84,7 @@ export default {
     return {
       preview: "",
       preview_index: "",
-      isLikedIcon: false,
+      isLikedIcon: null,
       likesPhotoId: null
     };
   },
@@ -111,7 +111,7 @@ export default {
       return "img-thumbnail-size" + this.selectedColumns;
     },
     likesClass() {
-      if (this.likesPhotoId !== null) {
+      if (this.isLikedIcon !== null) {
         return { likes: this.isLikedIcon, dislikes: !this.isLikedIcon };
       }
       return "";

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -31,17 +31,17 @@
                     @click="delPhoto"
                     v-if="isMyEvent"
                   ></i>
+                  <i class="fa fa-gratipay photo-favorites-icon"></i>
                   <a
                     :href="this.photos[preview_index].image_path"
                     :download="this.photos[preview_index].image_path"
                     @click.stop
-                    style="margin-top: auto; margin-left: auto;"
+                    style="margin-top: auto;"
                   >
                     <i class="fa fa-download mr-2" style="font-size: 27px;"></i>
                   </a>
                   <i class="del_button fa fa-times" @click="preview=''"></i>
                 </div>
-
                 <img :src="preview" class="preview-photo" />
               </div>
               <i
@@ -210,6 +210,13 @@ export default {
   margin-bottom: 0 !important;
   object-fit: cover;
   max-width: 100%;
+}
+.photo-favorites-icon {
+  margin-left: auto;
+  color: ivory;
+}
+.photo-favorites-icon.likes {
+  color: orangered;
 }
 
 .wrap {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -44,7 +44,7 @@
                   >
                     <i class="fa fa-download mr-2" style="font-size: 27px;"></i>
                   </a>
-                  <i class="del_button fa fa-times" @click="preview=''"></i>
+                  <i class="del_button fa fa-times" @click="initData"></i>
                 </div>
                 <img :src="preview" class="preview-photo" />
               </div>
@@ -140,11 +140,16 @@ export default {
       // TODO: event_idとphoto_idを保持しておく
       this.likesPhotoId = photo_id;
       console.log("お気に入り状態を変更する写真のID", this.likesPhotoId);
+    },
+    initData() {
+      this.preview = "";
     }
   },
   watch: {
     preview: {
       handler(val) {
+        // !罰ボタン以外の場所をクリックしたとき対策
+        this.isLikedIcon = null;
         if (val) {
           this.no_scroll();
         } else {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -155,29 +155,26 @@ export default {
         photo_id
       };
       const request_type = photo.is_favorite ? "DELETE" : "POST";
-      this.likesRequest(request_type, payload);
-      photo.is_favorite = !photo.is_favorite;
+      this.likesRequest(request_type, payload, photo);
     },
     initData() {
       this.preview = "";
     },
-    async likesRequest(request_type, payload) {
+    async likesRequest(request_type, payload, photo) {
       if (request_type === "DELETE") {
         delete payload.user_id;
         const response = await this.photoLikesDestroy(payload);
         console.log("DELETE response", response);
-        this.ifFailedLikes();
+        this.ifSuccessLikes(photo);
       } else {
         const response = await this.photoLikesStore(payload);
         console.log("POST response", response);
-        this.ifFailedLikes();
+        this.ifSuccessLikes(photo);
       }
     },
-    ifFailedLikes() {
-      if (!this.isSuccess) {
+    ifSuccessLikes(photo) {
+      if (this.isSuccess) {
         photo.is_favorite = !photo.is_favorite;
-      } else {
-        console.log("SUCCESS");
       }
     }
   },

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div>
+    <div v-show="endLoading===''">
       <transition-group
         id="img-thumbnail"
         class="d-flex justify-content-between flex-wrap mb-5 img-area"
@@ -108,7 +108,8 @@ export default {
       user: "users/user",
       isLogin: "users/isLogin",
       selectedColumns: "display/selectedColumns",
-      isSuccess: "status/isApiSuccess"
+      isSuccess: "status/isApiSuccess",
+      endLoading: "load/text"
     }),
     alt() {
       return function(id) {
@@ -363,5 +364,8 @@ export default {
 .fade-enter-active,
 .fade-leave-active {
   transition: all 0.5s;
+}
+.fade-leave-active {
+  position: absolute;
 }
 </style>

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -15,6 +15,7 @@
           @click="openPreview(index)"
         />
         <i
+          v-if="isLogin"
           class="fa fa-gratipay photo-likes-icon thumbnail"
           :class="likesClass(image)"
           @click="toggleLikesIcon(image)"
@@ -98,7 +99,9 @@ export default {
   computed: {
     ...mapGetters({
       user: "users/user",
-      selectedColumns: "display/selectedColumns"
+      isLogin: "users/isLogin",
+      selectedColumns: "display/selectedColumns",
+      isSuccess: "status/isApiSuccess"
     }),
     alt() {
       return function(id) {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -126,6 +126,7 @@ export default {
     }
   },
   methods: {
+    ...mapActions("photos", ["photoLikesStore", "photoLikesDestroy"]),
     openPreview(index) {
       if (this.photos[index]) {
         this.preview = this.photos[index].image_path;
@@ -144,12 +145,37 @@ export default {
       }
     },
     toggleLikesIcon(photo) {
+      const user_id = this.user.id;
       const photo_id = photo.id;
+      const payload = {
+        user_id,
+        photo_id
+      };
       const request_type = photo.is_favorite ? "DELETE" : "POST";
-      // TODO: アクション起動
+      this.likesRequest(request_type, payload);
+      photo.is_favorite = !photo.is_favorite;
     },
     initData() {
       this.preview = "";
+    },
+    async likesRequest(request_type, payload) {
+      if (request_type === "DELETE") {
+        delete payload.user_id;
+        const response = await this.photoLikesDestroy(payload);
+        console.log("DELETE response", response);
+        this.ifFailedLikes();
+      } else {
+        const response = await this.photoLikesStore(payload);
+        console.log("POST response", response);
+        this.ifFailedLikes();
+      }
+    },
+    ifFailedLikes() {
+      if (!this.isSuccess) {
+        photo.is_favorite = !photo.is_favorite;
+      } else {
+        console.log("SUCCESS");
+      }
     }
   },
   watch: {
@@ -253,6 +279,10 @@ export default {
   margin-left: auto;
   margin-right: 6px;
   animation: dislike 0.5s ease;
+  cursor: pointer;
+}
+.photo-likes-icon:hover {
+  transform: scale(1.02, 1.02);
 }
 .photo-likes-icon.likes {
   color: palevioletred;

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -152,10 +152,11 @@ export default {
       const photo_id = photo.id;
       const payload = {
         user_id,
-        photo_id
+        photo_id,
+        photo
       };
       const request_type = photo.is_favorite ? "DELETE" : "POST";
-      this.likesRequest(request_type, payload, photo);
+      this.likesRequest(request_type, payload);
     },
     initData() {
       this.preview = "";
@@ -164,12 +165,10 @@ export default {
       if (request_type === "DELETE") {
         delete payload.user_id;
         const response = await this.photoLikesDestroy(payload);
-        console.log("DELETE response", response);
-        this.ifSuccessLikes(photo);
+        this.ifSuccessLikes(payload.photo);
       } else {
         const response = await this.photoLikesStore(payload);
-        console.log("POST response", response);
-        this.ifSuccessLikes(photo);
+        this.ifSuccessLikes(payload.photo);
       }
     },
     ifSuccessLikes(photo) {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -23,7 +23,7 @@
       </div>
       <p v-show="!photos.length">写真はまだありません</p>
     </div>
-    <div class="wrap" v-if="preview" @click="preview=''">
+    <div class="wrap" v-if="preview && photos.length > 0" @click="preview=''">
       <div class="inner_wrap">
         <div class="content">
           <div class="preview_set" @click.stop>
@@ -54,7 +54,7 @@
                   >
                     <i class="fa fa-download mr-2" style="font-size: 27px;"></i>
                   </a>
-                  <i class="del_button fa fa-times" @click="initData"></i>
+                  <i class="del_button fa fa-times" @click="initPreview"></i>
                 </div>
                 <img :src="preview" class="preview-photo" />
               </div>
@@ -157,8 +157,9 @@ export default {
       };
       const request_type = photo.is_favorite ? "DELETE" : "POST";
       this.likesRequest(request_type, payload);
+      this.initPreview();
     },
-    initData() {
+    initPreview() {
       this.preview = "";
     },
     async likesRequest(request_type, payload, photo) {
@@ -190,7 +191,7 @@ export default {
   },
   beforeDestroy() {
     const user_id = this.user.id;
-  },
+  }
   mixins: [scrollControllable]
 };
 </script>

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -31,7 +31,11 @@
                     @click="delPhoto"
                     v-if="isMyEvent"
                   ></i>
-                  <i class="fa fa-gratipay photo-favorites-icon"></i>
+                  <i
+                    class="fa fa-gratipay photo-likes-icon"
+                    :class="{ 'likes': isLikedIcon }"
+                    @click="toggleLikesIcon(photos[preview_index].id)"
+                  ></i>
                   <a
                     :href="this.photos[preview_index].image_path"
                     :download="this.photos[preview_index].image_path"
@@ -79,7 +83,9 @@ export default {
   data() {
     return {
       preview: "",
-      preview_index: ""
+      preview_index: "",
+      isLikedIcon: false,
+      likesPhotoId: null
     };
   },
   computed: {
@@ -122,6 +128,12 @@ export default {
         this.preview = "";
         this.preview_index = "";
       }
+    },
+    toggleLikesIcon(photo_id) {
+      this.isLikedIcon = !this.isLikedIcon;
+      // TODO: event_idとphoto_idを保持しておく
+      this.likesPhotoId = photo_id;
+      console.log("お気に入り状態を変更する写真のID", this.likesPhotoId);
     }
   },
   watch: {
@@ -211,12 +223,27 @@ export default {
   object-fit: cover;
   max-width: 100%;
 }
-.photo-favorites-icon {
+.photo-likes-icon {
   margin-left: auto;
+  margin-right: 6px;
   color: ivory;
+  transition: 0.5s;
 }
-.photo-favorites-icon.likes {
-  color: orangered;
+.photo-likes-icon.likes {
+  color: palevioletred;
+}
+@keyframes jump {
+  0% {
+    transform: translateY(0px);
+  }
+
+  50% {
+    transform: translateY(5px);
+  }
+
+  100% {
+    transform: translateY(0px);
+  }
 }
 
 .wrap {

--- a/yeahcheese/resources/js/components/PhotoList.vue
+++ b/yeahcheese/resources/js/components/PhotoList.vue
@@ -33,7 +33,7 @@
                   ></i>
                   <i
                     class="fa fa-gratipay photo-likes-icon"
-                    :class="{ 'likes': isLikedIcon }"
+                    :class="likesClass"
                     @click="toggleLikesIcon(photos[preview_index].id)"
                   ></i>
                   <a
@@ -109,6 +109,12 @@ export default {
     },
     imgThumbnailSize() {
       return "img-thumbnail-size" + this.selectedColumns;
+    },
+    likesClass() {
+      if (this.likesPhotoId !== null) {
+        return { likes: this.isLikedIcon, dislikes: !this.isLikedIcon };
+      }
+      return "";
     }
   },
   methods: {
@@ -226,21 +232,37 @@ export default {
 .photo-likes-icon {
   margin-left: auto;
   margin-right: 6px;
-  color: ivory;
-  transition: 0.5s;
 }
 .photo-likes-icon.likes {
   color: palevioletred;
+  animation: like 0.5s ease;
 }
-@keyframes jump {
+.photo-likes-icon.dislikes {
+  color: ivory;
+  animation: dislike 0.5s ease;
+}
+
+@keyframes like {
   0% {
     transform: translateY(0px);
   }
-
   50% {
-    transform: translateY(5px);
+    transform: translateY(-5px);
+    text-shadow: 0 0 10px palevioletred;
   }
+  100% {
+    transform: translateY(0px);
+  }
+}
 
+@keyframes dislike {
+  0% {
+    transform: translateY(0px);
+  }
+  50% {
+    transform: translateY(-5px);
+    text-shadow: 0 0 10px ivory;
+  }
   100% {
     transform: translateY(0px);
   }

--- a/yeahcheese/resources/js/constants.js
+++ b/yeahcheese/resources/js/constants.js
@@ -10,5 +10,7 @@ export const Route = {
   EVENTS_DESTROY: (id) => '/api/events/' + id,
   PHOTOS_INDEX: (id) => '/api/events/' + id + '/photos',
   PHOTOS_STORE: (id) => '/api/events/' + id + '/photos',
-  PHOTOS_DESTROY: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id
+  PHOTOS_DESTROY: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id,
+  PHOTOS_ADD_LIKES: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id, // ! URLはバックエンドと合わせる
+  PHOTOS_DELETE_LIKES: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id, // ! URLはバックエンドと合わせる
 };

--- a/yeahcheese/resources/js/constants.js
+++ b/yeahcheese/resources/js/constants.js
@@ -11,6 +11,7 @@ export const Route = {
   PHOTOS_INDEX: (id) => '/api/events/' + id + '/photos',
   PHOTOS_STORE: (id) => '/api/events/' + id + '/photos',
   PHOTOS_DESTROY: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id,
-  PHOTOS_ADD_LIKES: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id, // ! URLはバックエンドと合わせる
-  PHOTOS_DELETE_LIKES: (event_id, photo_id) => '/api/events/' + event_id + '/photos/' + photo_id, // ! URLはバックエンドと合わせる
+  PHOTOS_LIKES_INDEX: '/api/likes',
+  PHOTOS_ADD_LIKES: '/api/likes',
+  PHOTOS_DELETE_LIKES: '/api/likes',
 };

--- a/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
+++ b/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
@@ -1,0 +1,37 @@
+<template>
+  <div id="user-favorite-photos" v-if="isLogin">
+    <photo-list
+      :photos="getPhotosForEventId(event.id) || []"
+      :event="this.event"
+      :isMyEvent="isMyEventByEventId(event.id)"
+    />
+  </div>
+</template>
+
+<script>
+import { mapGetters, mapActions } from "vuex";
+import photoList from "../components/PhotoList";
+export default {
+  name: "UserFavoritePhotos",
+  components: {
+    photoList
+  },
+  computed: {
+    ...mapGetters({
+      isMyEventByEventId: "events/isMyEventByEventId",
+      getPhotosForEventId: "photos/getPhotosForEventId",
+      isLogin: "users/isLogin",
+      favoritePhotos: "photos/userFavoritePhotos"
+    })
+  },
+  methods: {
+    ...mapActions("photos", ["photoLikesIndex"])
+  },
+  created() {
+    this.photoLikesIndex();
+  }
+};
+</script>
+
+<style scoped>
+</style>

--- a/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
+++ b/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
@@ -1,28 +1,68 @@
 <template>
   <div id="user-favorite-photos" v-if="isLogin">
-    <photo-list
-      :photos="getPhotosForEventId(event.id) || []"
-      :event="this.event"
-      :isMyEvent="isMyEventByEventId(event.id)"
-    />
+    <div class="option" :class="isFlex">
+      <h2 class="greet-text" :class="isFullWidth">{{ greetText }}</h2>
+      <change-columns
+        :min="minColumn"
+        :max="maxColumn"
+        :device="accessDevice"
+        :selected="selectedColumns"
+      ></change-columns>
+    </div>
+    <photo-list :photos="favoritePhotos || []" :event="event" />
   </div>
 </template>
 
 <script>
 import { mapGetters, mapActions } from "vuex";
 import photoList from "../components/PhotoList";
+import ChangeColumns from "../components/ChangeColumns";
 export default {
   name: "UserFavoritePhotos",
   components: {
-    photoList
+    photoList,
+    ChangeColumns
+  },
+  data() {
+    return {
+      event: {}
+    };
   },
   computed: {
     ...mapGetters({
       isMyEventByEventId: "events/isMyEventByEventId",
       getPhotosForEventId: "photos/getPhotosForEventId",
+      user: "users/user",
       isLogin: "users/isLogin",
-      favoritePhotos: "photos/userFavoritePhotos"
-    })
+      favoritePhotos: "photos/userFavoritePhotos",
+      selectedColumns: "display/selectedColumns",
+      accessDevice: "display/accessDevice"
+    }),
+    greetText() {
+      return this.user.name + "さんのお気に入りの写真一覧";
+    },
+    minColumn() {
+      // * accessDeviceがtrueのときはPCからのアクセス
+      // * PCの場合は最小列数は2
+      const min = this.accessDevice ? 2 : 1;
+      return min;
+    },
+    maxColumn() {
+      // * accessDeviceがtrueのときはPCからのアクセス
+      // * PCの場合は最大列数は5
+      const max = this.accessDevice ? 5 : 2;
+      return max;
+    },
+    isFullWidth() {
+      // * accessDeviceがtrueのときはPCからのアクセス
+      // * スマホの場合は横幅をフルで取る
+      return this.accessDevice ? "ml-4 mr-4" : "is-full-width";
+    },
+    isFlex() {
+      // * accessDeviceがtrueのときはPCからのアクセス
+      // * スマホの場合はフレックス対応でないようにする
+      return this.accessDevice ? "d-flex mb-2" : "";
+    }
   },
   methods: {
     ...mapActions("photos", ["photoLikesIndex"])
@@ -34,4 +74,24 @@ export default {
 </script>
 
 <style scoped>
+.greet-text {
+  color: rgba(20, 20, 20, 0.7);
+  text-align: center;
+  padding: 0 16px;
+}
+.d-flex.option * {
+  padding: 0 16px;
+}
+h2.is-full-width {
+  text-align: center;
+}
+.is-full-width {
+  display: block;
+  width: 100%;
+  margin: 16px 0;
+  padding: 32px;
+}
+.is-full-width * {
+  margin-left: 0;
+}
 </style>

--- a/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
+++ b/yeahcheese/resources/js/pages/UserFavoritePhotos.vue
@@ -9,7 +9,7 @@
         :selected="selectedColumns"
       ></change-columns>
     </div>
-    <photo-list :photos="favoritePhotos || []" :event="event" />
+    <photo-list :photos="likedPhotos || []" :event="event" />
   </div>
 </template>
 
@@ -34,7 +34,7 @@ export default {
       getPhotosForEventId: "photos/getPhotosForEventId",
       user: "users/user",
       isLogin: "users/isLogin",
-      favoritePhotos: "photos/userFavoritePhotos",
+      likedPhotos: "photos/userFavoritePhotos",
       selectedColumns: "display/selectedColumns",
       accessDevice: "display/accessDevice"
     }),

--- a/yeahcheese/resources/js/router/index.js
+++ b/yeahcheese/resources/js/router/index.js
@@ -6,6 +6,7 @@ import EventsIndex from '../pages/eventsIndex.vue';
 import EventsShow from '../pages/eventShow.vue';
 import EventStore from '../pages/eventStore.vue';
 import EventEdit from '../pages/EventEdit.vue';
+import UserFavoritePhotos from '../pages/UserFavoritePhotos.vue';
 import Login from '../pages/login.vue';
 import Register from '../pages/register.vue'
 import Index from '../pages/index.vue';
@@ -55,6 +56,12 @@ const routes = [
     path: '/events/event-:id/edit',
     name: 'eventEdit',
     component: EventEdit,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: '/photos/favorite',
+    name: 'photoFavorite',
+    component: UserFavoritePhotos,
     meta: { requiresAuth: true }
   },
   {

--- a/yeahcheese/resources/js/store/photos/actions.js
+++ b/yeahcheese/resources/js/store/photos/actions.js
@@ -55,18 +55,20 @@ export default {
       return response;
     }
   },
-  async photoLikesStore({ commit }, likesId) {
-    const response = await api.photoLikesStore(likesId);
+  async photoLikesStore({ commit }, payload) {
+    const response = await api.photoLikesStore(payload);
     const isSuccess = store.getters['status/isApiSuccess'];
     if (isSuccess) {
-      commit("pushLikedPhoto", response.data);
+      commit("pushLikedPhoto", response);
+      return response;
     }
   },
-  async photoLikesDestroy({ commit }, dislikesId) {
-    const response = await api.photoLikesDestroy(dislikesId);
+  async photoLikesDestroy({ commit }, payload) {
+    const response = await api.photoLikesDestroy(payload);
     const isSuccess = store.getters['status/isApiSuccess'];
     if (isSuccess) {
-      commit("deleteLikedPhoto", response.data);
+      commit("deleteLikedPhoto", response);
+      return response;
     }
   }
 }

--- a/yeahcheese/resources/js/store/photos/actions.js
+++ b/yeahcheese/resources/js/store/photos/actions.js
@@ -51,7 +51,7 @@ export default {
     const response = await api.photoLikesIndex();
     const isSuccess = store.getters['status/isApiSuccess'];
     if (isSuccess) {
-      commit("setLikedPhotos", response.data);
+      commit("setLikedPhotos", response);
       return response;
     }
   },

--- a/yeahcheese/resources/js/store/photos/actions.js
+++ b/yeahcheese/resources/js/store/photos/actions.js
@@ -46,5 +46,27 @@ export default {
     } else {
       return response.errors;
     }
+  },
+  async photoLikesIndex({ commit }) {
+    const response = await api.photoLikesIndex();
+    const isSuccess = store.getters['status/isApiSuccess'];
+    if (isSuccess) {
+      commit("setLikedPhotos", response.data);
+      return response;
+    }
+  },
+  async photoLikesStore({ commit }, likesId) {
+    const response = await api.photoLikesStore(likesId);
+    const isSuccess = store.getters['status/isApiSuccess'];
+    if (isSuccess) {
+      commit("pushLikedPhoto", response.data);
+    }
+  },
+  async photoLikesDestroy({ commit }, dislikesId) {
+    const response = await api.photoLikesDestroy(dislikesId);
+    const isSuccess = store.getters['status/isApiSuccess'];
+    if (isSuccess) {
+      commit("deleteLikedPhoto", response.data);
+    }
   }
 }

--- a/yeahcheese/resources/js/store/photos/actions.js
+++ b/yeahcheese/resources/js/store/photos/actions.js
@@ -55,19 +55,19 @@ export default {
       return response;
     }
   },
-  async photoLikesStore({ commit }, payload) {
+  async photoLikesStore({ commit }, { photo, ...payload }) {
     const response = await api.photoLikesStore(payload);
     const isSuccess = store.getters['status/isApiSuccess'];
     if (isSuccess) {
-      commit("pushLikedPhoto", response);
+      commit("pushLikedPhoto", photo);
       return response;
     }
   },
-  async photoLikesDestroy({ commit }, payload) {
+  async photoLikesDestroy({ commit }, { photo, ...payload }) {
     const response = await api.photoLikesDestroy(payload);
     const isSuccess = store.getters['status/isApiSuccess'];
     if (isSuccess) {
-      commit("deleteLikedPhoto", response);
+      commit("deleteLikedPhoto", photo);
       return response;
     }
   }

--- a/yeahcheese/resources/js/store/photos/getters.js
+++ b/yeahcheese/resources/js/store/photos/getters.js
@@ -8,6 +8,6 @@ const getters = {
     const obj = state.eventPhotos.find(event => event.event_id == id.toString())
     return obj.photos.findIndex(photo => photo.id == photo_id);
   },
-  userFavoritePhotos: state => state.likedPhotos;
+  userFavoritePhotos: state => state.likedPhotos,
 }
 export default getters

--- a/yeahcheese/resources/js/store/photos/getters.js
+++ b/yeahcheese/resources/js/store/photos/getters.js
@@ -7,6 +7,7 @@ const getters = {
   getPhotoIndexForEventId: state => (id, photo_id) => {
     const obj = state.eventPhotos.find(event => event.event_id == id.toString())
     return obj.photos.findIndex(photo => photo.id == photo_id);
-  }
+  },
+  userFavoritePhotos: state => state.likedPhotos;
 }
 export default getters

--- a/yeahcheese/resources/js/store/photos/index.js
+++ b/yeahcheese/resources/js/store/photos/index.js
@@ -4,6 +4,7 @@ import actions from './actions';
 
 const state = {
   eventPhotos: [],// {event_id : 1, photos}のオブジェクト配列
+  likedPhotos: [],
 }
 
 export default {

--- a/yeahcheese/resources/js/store/photos/mutations.js
+++ b/yeahcheese/resources/js/store/photos/mutations.js
@@ -21,7 +21,6 @@ export default {
     state.likedPhotos = likePhotos;
   },
   pushLikedPhoto(state, photo) {
-    console.log(photo);
     state.likedPhotos.push(photo);
     state.eventPhotos.forEach((eventInfo) => {
       if (eventInfo.photos.includes(photo.photo_id)) {
@@ -31,7 +30,6 @@ export default {
     });
   },
   deleteLikedPhoto(state, photo) {
-    console.log(photo);
     //eventPhotosとlikedPhotosを変更
     const index = state.likedPhotos.findIndex((p) => {
       return p.id == photo.id;

--- a/yeahcheese/resources/js/store/photos/mutations.js
+++ b/yeahcheese/resources/js/store/photos/mutations.js
@@ -15,5 +15,17 @@ export default {
   },
   delPhotos(state) {
     state.eventPhotos = []
+  },
+  setLikedPhotos(state, likePhotos) {
+    state.likedPhotos = likePhotos;
+  },
+  pushLikedPhoto(state, likePhoto) {
+    state.likedPhotos.push(likePhoto);
+  },
+  deleteLikedPhoto(state, disLikePhoto) {
+    const index = state.likedPhotos.findIndex((photo) => {
+      return photo.id = disLikePhoto.id;
+    });
+    state.likedPhotos.splice(index, 1);
   }
 }

--- a/yeahcheese/resources/js/store/photos/mutations.js
+++ b/yeahcheese/resources/js/store/photos/mutations.js
@@ -21,7 +21,8 @@ export default {
     state.likedPhotos = likePhotos;
   },
   pushLikedPhoto(state, photo) {
-    state.likedPhotos.push(photo);
+    const pushIdx = state.likedPhotos.length;
+    state.likedPhotos.splice(pushIdx, 1, photo);
     state.eventPhotos.forEach((eventInfo) => {
       if (eventInfo.photos.includes(photo.photo_id)) {
         const idx = eventInfo.photos.findIndex((p) => p.id === photo.photo_id);

--- a/yeahcheese/resources/js/store/photos/mutations.js
+++ b/yeahcheese/resources/js/store/photos/mutations.js
@@ -16,16 +16,31 @@ export default {
   delPhotos(state) {
     state.eventPhotos = []
   },
+
   setLikedPhotos(state, likePhotos) {
     state.likedPhotos = likePhotos;
   },
   pushLikedPhoto(state, likePhoto) {
     state.likedPhotos.push(likePhoto);
+    state.eventPhotos.forEach((eventInfo) => {
+      console.log(eventInfo);
+      if (eventInfo.photos.includes(likePhoto.photo_id)) {
+        const idx = eventInfo.photos.findIndex((p) => p.id === likePhoto.photo_id);
+        eventInfo.photos[idx].is_favorite = true;
+      }
+    });
   },
-  deleteLikedPhoto(state, disLikePhoto) {
+  deleteLikedPhoto(state, dislikePhoto) {
+    //eventPhotosとlikedPhotosを変更
     const index = state.likedPhotos.findIndex((photo) => {
-      return photo.id = disLikePhoto.id;
+      return photo.id = dislikePhoto.id;
     });
     state.likedPhotos.splice(index, 1);
+    state.eventPhotos.forEach((eventInfo) => {
+      if (eventInfo.photos.includes(dislikePhoto.photo_id)) {
+        const idx = eventInfo.photos.findIndex((p) => p.id === likePhoto.photo_id);
+        eventInfo.photos[idx].is_favorite = false;
+      }
+    });
   }
 }

--- a/yeahcheese/resources/js/store/photos/mutations.js
+++ b/yeahcheese/resources/js/store/photos/mutations.js
@@ -20,25 +20,26 @@ export default {
   setLikedPhotos(state, likePhotos) {
     state.likedPhotos = likePhotos;
   },
-  pushLikedPhoto(state, likePhoto) {
-    state.likedPhotos.push(likePhoto);
+  pushLikedPhoto(state, photo) {
+    console.log(photo);
+    state.likedPhotos.push(photo);
     state.eventPhotos.forEach((eventInfo) => {
-      console.log(eventInfo);
-      if (eventInfo.photos.includes(likePhoto.photo_id)) {
-        const idx = eventInfo.photos.findIndex((p) => p.id === likePhoto.photo_id);
+      if (eventInfo.photos.includes(photo.photo_id)) {
+        const idx = eventInfo.photos.findIndex((p) => p.id === photo.photo_id);
         eventInfo.photos[idx].is_favorite = true;
       }
     });
   },
-  deleteLikedPhoto(state, dislikePhoto) {
+  deleteLikedPhoto(state, photo) {
+    console.log(photo);
     //eventPhotosとlikedPhotosを変更
-    const index = state.likedPhotos.findIndex((photo) => {
-      return photo.id = dislikePhoto.id;
+    const index = state.likedPhotos.findIndex((p) => {
+      return p.id == photo.id;
     });
     state.likedPhotos.splice(index, 1);
     state.eventPhotos.forEach((eventInfo) => {
-      if (eventInfo.photos.includes(dislikePhoto.photo_id)) {
-        const idx = eventInfo.photos.findIndex((p) => p.id === likePhoto.photo_id);
+      if (eventInfo.photos.includes(photo.photo_id)) {
+        const idx = eventInfo.photos.findIndex((p) => p.id === photo.photo_id);
         eventInfo.photos[idx].is_favorite = false;
       }
     });

--- a/yeahcheese/tests/Feature/FavoriteControllerTest.php
+++ b/yeahcheese/tests/Feature/FavoriteControllerTest.php
@@ -17,7 +17,9 @@ class FavoriteControllerTest extends TestCase
 {
     use RefreshDatabase;
 
-    public $user, $event, $photo;
+    public $user;
+    public $event;
+    public $photo;
 
     public function setUp(): void
     {


### PR DESCRIPTION
## やったこと
- イベント詳細画面において、個々の写真に対してログインユーザーが「お気に入り登録」できるようにした
  - 一覧でのお気に入り登録と、プレビュー画面での登録ができる
  - 登録した写真は、「お気に入り写真一覧」で確認できる
  - 「お気に入り写真一覧」からも、お気に入りの削除が可能
  - ゲストユーザーはお気に入り登録ができない

### イベント詳細のお気に入り登録
![スクリーンショット 2020-05-28 16 09 08](https://user-images.githubusercontent.com/54382187/83112054-8adc8080-a100-11ea-87d0-75dd2cd7c139.png)

### プレビュー画面のお気に入り登録
![スクリーンショット 2020-05-28 16 09 25](https://user-images.githubusercontent.com/54382187/83112109-a2b40480-a100-11ea-8556-68de83ee2775.png)

### 登録・削除にもローディング画面がつく
![スクリーンショット 2020-05-28 16 11 50](https://user-images.githubusercontent.com/54382187/83112161-b2cbe400-a100-11ea-88de-c486698b5c0a.png)

### イベント一覧のお気に入り登録済みマーク
![スクリーンショット 2020-05-28 16 12 06](https://user-images.githubusercontent.com/54382187/83112200-c5461d80-a100-11ea-88c0-133c86b54d1e.png)

### プレビュー画面のお気に入り登録済みマーク
![スクリーンショット 2020-05-28 16 12 18](https://user-images.githubusercontent.com/54382187/83112246-d5f69380-a100-11ea-810f-031e86c51470.png)

### お気に入り写真一覧画面
![スクリーンショット 2020-05-28 16 33 59](https://user-images.githubusercontent.com/54382187/83112391-0f2f0380-a101-11ea-927a-b19109a613ff.png)
